### PR TITLE
Fixing block polling and updating addresses

### DIFF
--- a/apps/api/.env
+++ b/apps/api/.env
@@ -1,5 +1,5 @@
 # .env file
 
-RPC_URL=http://external-testnet.bvmdev.cc:18546
-WEBSOCKET_URL=ws://external-testnet.bvmdev.cc:28546
+RPC_URL=https://testnet.rpc.hemi.network/rpc
+WEBSOCKET_URL=wss://testnet.rpc.hemi.network/wsrpc
 USE_WEBSOCKET_NODE_L2=true

--- a/apps/api/src/application/polling/pollingService.ts
+++ b/apps/api/src/application/polling/pollingService.ts
@@ -6,8 +6,8 @@ import { L2Block } from "@cryptochords/shared";
 export class PollingService {
   constructor(private blockRepository: BlockRepository) {}
 
-  execute(wss: WebSocketServer, websocketUrl: string): void {
-    this.blockRepository.execute(websocketUrl)
+  execute(wss: WebSocketServer, url: string): void {
+    this.blockRepository.execute(url)
 
     this.blockRepository.on(TxTypesEnum.Block, (l2Block: L2Block) => BroadcastToClients(wss, l2Block));
     this.blockRepository.on(TxTypesEnum.Eth, (l2Block: L2Block) => BroadcastToClients(wss, l2Block));

--- a/apps/api/src/domain/repositories/BlockRepository.ts
+++ b/apps/api/src/domain/repositories/BlockRepository.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
 export interface BlockRepository extends EventEmitter {
-  execute(websocketUrl: string): void
+  execute(url: string): void
   stop(): void
 }

--- a/apps/api/src/infrastructure/repositories/blockPolling.ts
+++ b/apps/api/src/infrastructure/repositories/blockPolling.ts
@@ -11,8 +11,8 @@ export class BlockPollingRepository extends EventEmitter implements BlockReposit
   private latestBlockNumber = BigInt(0)
   private pollingIntervalId: NodeJS.Timeout | null = null;
 
-  execute(websocketUrl: string, pollingInterval = 5000): void {
-    const web3 = new Web3(websocketUrl);
+  execute(rpcUrl: string, pollingInterval = 5000): void {
+    const web3 = new Web3(rpcUrl);
     this.poll(web3, pollingInterval)
   }
 

--- a/apps/api/src/presentation/routes/PollingRoute.ts
+++ b/apps/api/src/presentation/routes/PollingRoute.ts
@@ -6,19 +6,22 @@ import 'dotenv/config';
 
 export class PollingRoute {
   private pollingService: PollingService;
+  private url: string;
 
   constructor() {
     if (process.env['USE_WEBSOCKET_NODE_L2'] === 'true') {
+      this.url = process.env['WEBSOCKET_URL'] as string
       const blockWebsocketRepository = new BlockWebsocketRepository();
       this.pollingService = new PollingService(blockWebsocketRepository);
     } else {
+      this.url = process.env['RPC_URL'] as string
       const blockPollingRepository = new BlockPollingRepository();
       this.pollingService = new PollingService(blockPollingRepository);
     }
   }
 
   public initialize(wss: WebSocketServer): void {
-    this.pollingService.execute(wss, process.env['WEBSOCKET_URL'] as string);
+    this.pollingService.execute(wss, this.url);
   }
 
   public stop(): void {


### PR DESCRIPTION
This PR enables the RPC polling strategy (when websocket connection is not available) and modifies RPC / WebSocket addresses to the Hemi node.