### PR TITLE
bump to 1.0.10

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cryptochords",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cryptochords",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crypto-chords-api",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "description": "CryptoChords API",
   "main": "src/server.ts",
   "scripts": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bvm-crypto-chords-webapp",
-  "version": "1.0.8",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bvm-crypto-chords-webapp",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crypto-chords-web",
   "private": true,
-  "version": "1.0.8",
+  "version": "1.0.10",
   "description": "CryptoChords Web",
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
     },
     "apps/api": {
       "name": "crypto-chords-api",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "license": "ISC",
       "dependencies": {
         "@cryptochords/shared": "*",
@@ -43,7 +43,7 @@
     },
     "apps/web": {
       "name": "crypto-chords-web",
-      "version": "1.0.8",
+      "version": "1.0.10",
       "dependencies": {
         "@cryptochords/shared": "*",
         "react": "^18.2.0",


### PR DESCRIPTION
Skipping the `1.0.9` version  to avoid cache issues since it was generated a docker image with an error previously.