### PR TITLE
fix transactions label colors

### DIFF
--- a/apps/web/src/presentation/common/presenter/transactions/TransactionsPresenter.ts
+++ b/apps/web/src/presentation/common/presenter/transactions/TransactionsPresenter.ts
@@ -1,6 +1,5 @@
 import { Event, Observable, TxTypesEnum } from '@cryptochords/shared'
 import { ListTransactionsService } from '../../../../application/services/ListTransactions/ListTransactionsService'
-import { TransactionColor } from '../../../../domain/valueObjects/TransactionColor'
 import { Presenter } from '../../base/Presenter'
 import { TransactionsPresenterState } from './TransactionsPresenterState'
 
@@ -13,6 +12,13 @@ const titleMap: Map<TxTypesEnum, string> = new Map([
   [TxTypesEnum.Eth, 'ETH'],
   [TxTypesEnum.Pop, 'PoP'],
   [TxTypesEnum.Btc, 'BTC']
+])
+
+const rgbMap: Map<TxTypesEnum, string> = new Map([
+  [TxTypesEnum.Block, '#10FF2A'],
+  [TxTypesEnum.Eth, '#00D3FF'],
+  [TxTypesEnum.Pop, '#DC53FF'],
+  [TxTypesEnum.Btc, '#FFB200']
 ])
 
 const messageMap: Map<TxTypesEnum, string> = new Map([
@@ -46,7 +52,7 @@ export class TransactionsPresenter extends Presenter<TransactionsPresenterState>
     this.changeState({
       transactions: response.transactions.map(transaction => ({
         type: titleMap.get(transaction.txType as TxTypesEnum) ?? 'Unknown',
-        color: TransactionColor.createByTxType(transaction.txType).value,
+        color: rgbMap.get(transaction.txType as TxTypesEnum) ?? '#fff',
         message: messageMap.get(transaction.txType as TxTypesEnum) ?? ' ',
         id: transaction.address,
         at: this.formatDate(transaction.timestamp),


### PR DESCRIPTION
Before:
![image](https://github.com/BVM-priv/CryptoChords/assets/8508384/db77674f-a14a-40d8-9c6b-3d6fb257eb1c)

After:
![image](https://github.com/BVM-priv/CryptoChords/assets/8508384/e8e45290-155b-48df-80a2-ed49bd75f8c0)
