### PR TITLE
Fix testnet deployment trigger

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -5,8 +5,8 @@
 # GitHub Actions workflow to deploy to the testnet prod environment.
 name: "Testnet"
 on:
-  push:
-    tags: [ "v*.*.*" ]
+  release:
+    types: [published]
 
 concurrency:
   group: "testnet-deploy-${{ github.event.number || github.ref }}"


### PR DESCRIPTION
At the moment, the testnet deployment is being triggered whenever a tag is pushed to any branch, allowing any user to publish content from their own branch. This PR aims to fix that by triggering the deployment only after a new release is created.