### PR TITLE
Add Support for Both ESM and CJS Modules for shared

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,7 @@
     "dev": "nodemon",
     "build": "tsc -p tsconfig.build.json",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
-    "start:api": "ts-node ./src/server.ts"
+    "start:api": "node dist/server.js"
   },
   "author": "",
   "license": "MIT",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,14 +2,26 @@
   "name": "@cryptochords/shared",
   "version": "0.0.0",
   "description": "Shared package for CryptoChords Application",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/types/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+  ".": {
+      "require": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/types/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./src/*": "./src/*"
   },
   "private": true,
   "scripts": {
-    "build": "tsc -p ./tsconfig.build.json",
+    "build:cjs": "tsc -p tsconfig.build.cjs.json",
+    "build:esm": "tsc -p tsconfig.build.esm.json",
+    "build": "npm run build:cjs && npm run build:esm",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "vitest run",

--- a/packages/shared/tsconfig.build.cjs.json
+++ b/packages/shared/tsconfig.build.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "./dist/types"
+  }
+}

--- a/packages/shared/tsconfig.build.esm.json
+++ b/packages/shared/tsconfig.build.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "outDir": "./dist/esm",
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "declarationDir": "./dist/types"
+  }
+}


### PR DESCRIPTION
This pull request updates the shared package to generate both CommonJS (CJS) and ECMAScript Module (ESM) builds, ensuring that both the api and web projects have full compatibility. With these changes, the api project can now run Node.js directly from the transpiled files (e.g., /dist/server.js), while the web project remains fully compatible with modern ESM tooling like Vite.

Dist folder structure:

<img width="198" alt="Captura de Tela 2024-12-30 às 15 24 14" src="https://github.com/user-attachments/assets/f3416b32-5aee-4e13-a285-12f38db834b7" />

Closes #107 