### PR TITLE
Add networkType URL parameter to enable dynamic network selection

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -107,6 +107,16 @@ The environment variables are defined in the `.env` file. The following variable
 
 - `VITE_LOGO_URL`: The URL of the logo. If it is not defined, the logo will point to the root of the web app and will not display the pointer cursor.
 
+### URL Parameter: networkType
+
+The web application supports a URL parameter called networkType, which allows users to specify the desired network (mainnet or testnet).
+
+Supported values:
+
+- `mainnet`: Connects the application to the main network.
+
+- `testnet`: Connects the application to the test network.
+
 ## Contribution
 
 If you want to contribute to this project and make it better, your help is very welcome.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@cryptochords/shared": "*",
+    "qs": "6.13.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-select": "5.9.0",

--- a/apps/web/src/presentation/common/presenter/app/AppPresenter.ts
+++ b/apps/web/src/presentation/common/presenter/app/AppPresenter.ts
@@ -1,3 +1,4 @@
+import qs from 'qs';
 import { CreateTransactionService } from '../../../../application/services/CreateTransaction/CreateTransactionService';
 import { GetSelectedNetworkService } from '../../../../application/services/GetSelectedNetwork/GetSelectedNetworkService';
 import { ListNetworksService } from '../../../../application/services/ListNetworks/ListNetworksService';
@@ -5,7 +6,7 @@ import { SwitchNetworkService } from '../../../../application/services/SwitchNet
 import { Presenter } from '../../base/Presenter';
 import { AppPresenterState } from './AppPresenterState';
 
-const initalState: AppPresenterState = {
+const initialState: AppPresenterState = {
   enableMainnet: import.meta.env.VITE_ENABLE_MAINNET === 'true',
   navMenuVisible: false,
   networkNames: [],
@@ -26,7 +27,7 @@ export class AppPresenter extends Presenter<AppPresenterState> {
     listNetworks: ListNetworksService,
   ) {
     super({
-      ...initalState,
+      ...initialState,
     });
     this.createTransactionService = createTransactionService;
     this.switchNetworkService = switchNetworkService;
@@ -36,7 +37,27 @@ export class AppPresenter extends Presenter<AppPresenterState> {
   }
 
   private async init() {
+    const networkType = this.parseUrlForNetworkType();
     await this.loadNetworkState();
+
+    if (this.isNetworkValid(networkType)) {
+      await this.selectNetwork(networkType!);
+    }
+  }
+
+  private parseUrlForNetworkType(): string | null {
+    const urlParams = qs.parse(window.location.search, {
+      ignoreQueryPrefix: true,
+    });
+    return urlParams.networkType as string | null;
+  }
+
+  private isNetworkValid(networkType: string | null): boolean {
+    return (
+      networkType !== null &&
+      this.state.networkNames.includes(networkType) &&
+      initialState.enableMainnet
+    );
   }
 
   private async loadNetworkState() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -587,6 +587,7 @@
       "version": "1.0.12",
       "dependencies": {
         "@cryptochords/shared": "*",
+        "qs": "6.13.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-select": "5.9.0",
@@ -936,6 +937,20 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "apps/web/node_modules/qs": {
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "apps/web/node_modules/tone": {


### PR DESCRIPTION
This PR introduces a new feature that allows dynamic selection of the network (`mainnet` or `testnet`) through the URL parameter `networkType`. This functionality enhances usability by enabling users to directly access the desired network when opening the Portal.

Closes #110 