### PR TITLE
fix explorer url for wallet address

### DIFF
--- a/apps/web/src/domain/entities/Network.ts
+++ b/apps/web/src/domain/entities/Network.ts
@@ -34,6 +34,10 @@ export class Network extends Entity<NetworkProps> {
     return `${this.explorerUrl}/block`;
   }
 
+  get addressUrl() {
+    return `${this.explorerUrl}/address`;
+  }
+
   get wsUrl() {
     return this.props.wsUrl;
   }

--- a/apps/web/src/domain/entities/Transaction.spec.ts
+++ b/apps/web/src/domain/entities/Transaction.spec.ts
@@ -56,7 +56,7 @@ describe('Transaction', () => {
       txType,
     });
 
-    const expectedUrl = `${mockNetwork.transactionUrl}/${mockAddress.value}`;
+    const expectedUrl = `${mockNetwork.addressUrl}/${mockAddress.value}`;
     expect(transaction.url).toBe(expectedUrl);
   });
 });

--- a/apps/web/src/domain/entities/Transaction.ts
+++ b/apps/web/src/domain/entities/Transaction.ts
@@ -40,6 +40,6 @@ export class Transaction {
       return `${this.props.network.blockUrl}/${this.props.address.value}`;
     }
 
-    return `${this.props.network.transactionUrl}/${this.props.address.value}`;
+    return `${this.props.network.addressUrl}/${this.props.address.value}`;
   }
 }


### PR DESCRIPTION
ETH wallet address link was leading to an transaction URL.

![image](https://github.com/user-attachments/assets/71950f3b-3ea5-47a1-9f2f-4727a8c3dea9)
