### PR TITLE
Fix repository links and apply hemi-socials

### DIFF
--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cryptochords",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cryptochords",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.3.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crypto-chords-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "CryptoChords API",
   "main": "src/server.ts",
   "scripts": {

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,10 +1,4 @@
 VITE_TESTNET_API_WEBSERVICE_URL=ws://localhost:3000
 VITE_MAINNET_API_WEBSERVICE_URL=ws://localhost:3001
 VITE_USE_API_MOCK=false
-VITE_GITHUB_URL=https://github.com/BVM-priv/CryptoChords/
-VITE_CONTRIBUTORS_URL=https://github.com/BVM-priv/CryptoChords/blob/master/CONTRIBUTING.md
-VITE_FEEDBACK_URL=https://github.com/BVM-priv/CryptoChords/issues/new
-VITE_DISCORD_URL=https://discord.gg/RyhaPp7NvQ
-VITE_X_URL=https://x.com/hemi_xyz
-VITE_LOGO_URL=https://x.com/hemi_xyz
 VITE_ENABLE_MAINNET=true

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -95,18 +95,6 @@ The environment variables are defined in the `.env` file. The following variable
 
 - `VITE_USE_API_MOCK`: A boolean that indicates if the API should be mocked.
 
-- `VITE_GITHUB_URL`: The URL of the GitHub repository. Used in the header and footer.
-
-- `VITE_CONTRIBUTORS_URL`: The URL of the contributors file. Used in the header.
-
-- `VITE_FEEDBACK_URL`: The URL of the feedback form. Used in the header.
-
-- `VITE_DISCORD_URL`: The URL of the Discord server. Used in the footer and 'Join Comunity' button.
-
-- `VITE_X_URL`: The URL of the X website. Used in the footer.
-
-- `VITE_LOGO_URL`: The URL of the logo. If it is not defined, the logo will point to the root of the web app and will not display the pointer cursor.
-
 ### URL Parameter: networkType
 
 The web application supports a URL parameter called networkType, which allows users to specify the desired network (mainnet or testnet).

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bvm-crypto-chords-webapp",
-  "version": "1.2.2",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bvm-crypto-chords-webapp",
-      "version": "1.2.2",
+      "version": "1.2.4",
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crypto-chords-web",
   "private": true,
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "CryptoChords Web",
   "type": "module",
   "scripts": {
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@cryptochords/shared": "*",
+    "hemi-socials": "1.0.0",
     "qs": "6.13.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/apps/web/src/presentation/react/components/JoinCommunityButton.tsx
+++ b/apps/web/src/presentation/react/components/JoinCommunityButton.tsx
@@ -1,3 +1,5 @@
+import { discordUrl } from 'hemi-socials';
+
 export const JoinCommunityButton = (props: { className?: string }) => {
   return (
     <a
@@ -15,7 +17,7 @@ export const JoinCommunityButton = (props: { className?: string }) => {
       bg-white
       pointer
       `}
-      href={import.meta.env.VITE_DISCORD_URL}
+      href={discordUrl}
       target="_blank"
     >
       Join Community

--- a/apps/web/src/presentation/react/components/Logo.tsx
+++ b/apps/web/src/presentation/react/components/Logo.tsx
@@ -1,7 +1,8 @@
 import logo from '/image/crypto-chords.svg';
+import { twitterUrl } from 'hemi-socials';
 
 export const Logo = function () {
-  const url = import.meta.env.VITE_LOGO_URL;
+  const url = twitterUrl;
   return (
     <a
       href={url ?? '#'}

--- a/apps/web/src/presentation/react/components/NavItems.tsx
+++ b/apps/web/src/presentation/react/components/NavItems.tsx
@@ -1,11 +1,14 @@
 import { NavItem } from './NavItem';
+import { githubUrl } from 'hemi-socials';
 
 export const NavItems = function (props: { className?: string }) {
   return (
     <nav className={`flex flex-row gap-8 ${props.className ?? ''}`}>
-      <NavItem href={import.meta.env.VITE_GITHUB_URL}>Github</NavItem>
-      <NavItem href={import.meta.env.VITE_CONTRIBUTORS_URL}>Contribute</NavItem>
-      <NavItem href={import.meta.env.VITE_FEEDBACK_URL}>Feedback</NavItem>
+      <NavItem href={`${githubUrl}/CryptoChords`}>Github</NavItem>
+      <NavItem href={`${githubUrl}/CryptoChords/blob/master/CONTRIBUTING.md`}>
+        Contribute
+      </NavItem>
+      <NavItem href={`${githubUrl}/CryptoChords/issues/new`}>Feedback</NavItem>
     </nav>
   );
 };

--- a/apps/web/src/presentation/react/components/Social.tsx
+++ b/apps/web/src/presentation/react/components/Social.tsx
@@ -1,5 +1,6 @@
 import discord from '/image/social/discord.svg';
 import x from '/image/social/x.svg';
+import { discordUrl, twitterUrl } from 'hemi-socials';
 
 export const Social = function (props: {
   className?: string;
@@ -9,18 +10,14 @@ export const Social = function (props: {
     <div
       className={`${props.className ?? ''} flex flex-row md:gap-10 max-md:gap-7`}
     >
-      <a
-        href={import.meta.env.VITE_DISCORD_URL}
-        target="_blank"
-        className="h-auto"
-      >
+      <a href={discordUrl} target="_blank" className="h-auto">
         <img
           src={discord}
           className={`md:w-10 max-md:w-${props.large ? 16 : 7}`}
           alt="Crypto Chords Discord"
         />
       </a>
-      <a href={import.meta.env.VITE_X_URL} target="_blank" className="h-auto">
+      <a href={twitterUrl} target="_blank" className="h-auto">
         <img
           src={x}
           className={`md:w-10 max-md:w-${props.large ? 16 : 7}`}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
     },
     "apps/api": {
       "name": "crypto-chords-api",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@cryptochords/shared": "*",
@@ -584,9 +584,10 @@
     },
     "apps/web": {
       "name": "crypto-chords-web",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "dependencies": {
         "@cryptochords/shared": "*",
+        "hemi-socials": "1.0.0",
         "qs": "6.13.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -8701,6 +8702,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hemi-socials": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hemi-socials/-/hemi-socials-1.0.0.tgz",
+      "integrity": "sha512-f1hiPt90QXTPXX9jb8fRuGvzWMkbBpBO/45m3s024Aa0JoSpeVt9AodkxHAnCfK5uTRDdKvbIB8dPU1sbGhOdA=="
     },
     "node_modules/hemi-viem": {
       "version": "1.7.0",


### PR DESCRIPTION
This PR fixes outdated URL references that were still pointing to the old BVM repositories. It also replaces social media URLs with references to the new `hemi-socials` package. Additionally, this PR bumps the version for a new release.

Closes #93 
Fixes #93 